### PR TITLE
Update compass-rails dependency

### DIFF
--- a/chosen-sass-bootstrap-rails.gemspec
+++ b/chosen-sass-bootstrap-rails.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.add_dependency "bootstrap-sass", "~> 3.1"
   gem.add_dependency "sass-rails",   "~> 4.0"
-  gem.add_dependency "compass-rails",   "~> 1.1"
+  gem.add_dependency "compass-rails",   "~> 2.0"
   gem.add_dependency "chosen-rails"
 end


### PR DESCRIPTION
The gem does not really depend on a specific version and the old version breaks my dependencies. 

It would be great if you can merge and publish a new gem version soon.
